### PR TITLE
Fix issue where figmint outputs invalid js

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -318,30 +318,12 @@ const Output = () => {
         prettier.format(
           `
         const styles = {
-        colors: ${util.inspect(colors, {
-          depth: Infinity,
-          compact: false,
-        })},
-        gradients: ${util.inspect(gradients, {
-          depth: Infinity,
-          compact: false,
-        })},
-        imageFills: ${util.inspect(imageFills, {
-          depth: Infinity,
-          compact: false,
-        })},
-        textStyles: ${util.inspect(textStyles, {
-          depth: Infinity,
-          compact: false,
-        })},
-        effectStyles: ${util.inspect(effectStyles, {
-          depth: Infinity,
-          compact: false,
-        })},
-        raw: ${util.inspect(styles, {
-          depth: Infinity,
-          compact: false,
-        })},
+        colors: ${JSON.stringify(colors)},
+        gradients: ${JSON.stringify(gradients)},
+        imageFills: ${JSON.stringify(imageFills)},
+        textStyles: ${JSON.stringify(textStyles)},
+        effectStyles: ${JSON.stringify(effectStyles)},
+        raw: ${JSON.stringify(styles)},
         }${typescript ? ' as const' : ''}
 
         ${


### PR DESCRIPTION
## Issue
When importing a significant number of elements (>100) the `util.inspect` doesn't behave properly – instead of outputting the objects it returns `... 1 more item` text.
## Example
```js
const styles = {
  fillStyles: [
    {
      key: 'KEY_1',
      name: 'RED',
      styles: [
        {
          type: 'SOLID',
          blendMode: 'NORMAL',
          color: 'hsla(0, 100%, 50%, 1)'
        }
      ]
    },
    // here lays 99 more fill styles
    {
      key: 'KEY_100',
      name: 'Generic / White',
      styles: [
        {
          type: 'SOLID',
          blendMode: 'NORMAL',
          color: 'hsl(0, 0%, 100%)'
        }
      ]
    },
    ... 1 more item
  ],
  textStyles: [],
  effectStyles: [],
  gridStyles: [],
  exports: []
}

export default styles
```

_Please note that I am using the old output format here, as it is what I am using in my project. However the same issue happens on the newest version of figmint_

## Concerns
Was there any specific reason to using `util.inspect` instead of `JSON.stringify`? Especially as the nodejs documentation states that
> The output of `util.inspect` may change at any time and should not be depended upon programmatically.